### PR TITLE
Update to use Log instead of Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ClickHouse client for [Crystal](http://crystal-lang.org/).
 
-- crystal: 0.27.2 0.33.0 0.34.0 0.35.1
+- crystal: 0.34.0 0.35.1 0.36.1
 
 ## Usage
 

--- a/src/clickhouse.cr
+++ b/src/clickhouse.cr
@@ -1,7 +1,7 @@
 # stdlib
 require "csv"
 require "http"
-require "logger"
+require "log"
 
 # shard
 require "var"
@@ -24,7 +24,7 @@ class Clickhouse
   var user            : String  = "default"
   var password        : String
   var profile         : String
-  var logger          : Logger  = Logger.new(nil)
+  var logger          : Log  = ::Log.for("clickhouse")
   var dns_timeout     : Float64 = 3.0
   var connect_timeout : Float64 = 5.0
   var read_timeout    : Float64 = 60.0

--- a/src/clickhouse/executable.cr
+++ b/src/clickhouse/executable.cr
@@ -27,8 +27,8 @@ module Clickhouse::Executable
 
     @before_execute.try &.each &.call(http_client, http_req)
     
-    logger.debug "HTTP request: #{http_req.path}"
-    logger.debug "HTTP headers: #{http_req.headers.to_h}"
+    logger.debug { "HTTP request: #{http_req.path}" }
+    logger.debug { "HTTP headers: #{http_req.headers.to_h}" }
 
     started_at = Pretty.now
     http_res   = http_client.exec(http_req)


### PR DESCRIPTION
Update to use Log instead of Logger, which is removed in 0.36. This s…tops < 0.34 from being used, as Log doesn't exist before. I didn't bump the version.